### PR TITLE
Updates README.md to clarify the third point under resources

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@ Every message on Twilio, every Coinbase transaction, and every Snap story uses T
 ## Resources
 - [Website](https://temporal.io/)
 - [Getting to know Temporal](https://youtu.be/wIpz4ioK0gI) (video)
-- [Getting Started](https://learn.temporal.io/getting_started/) (course)
+- [Getting Started](https://learn.temporal.io/getting_started/) (tutorials)
 - [Slack Community](https://t.mp/slack) 
 - [Documentation](https://docs.temporal.io/)
 


### PR DESCRIPTION
(this links to a set of tutorials rather than a training course).

## What was changed
I changed the parenthetical text in the third bullet point under resources. This currently states that the target of the link is a training course, but in fact it's a set of tutorials.

## Why?
The current text does not accurately portray the content

## Checklist
<!--- add/delete as needed --->

1. Closes: N/A

2. How was this tested:
I viewed the README.md file in my browser.

3. Any docs updates needed? No