### PR TITLE
Update README.md to include pinned repos

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,3 @@
-# temporalio-readme-prototype
-
 **Temporal** delivers an open-source Durable Execution platform that abstracts away the complexity of building scalable, reliable distributed systems. It presents a development abstraction that preserves complete application state so that in the case of a host or software failure it can seamlessly migrate execution to another machine.
 
 ## 📝 Got 5 minutes? Help us make Temporal even better!


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I added a "Pinned" section to the README. 

In an unrelated change, I capitalized "Durable Execution" (as per our convention) and changed "system" to "platform" to reflect our messaging.

## Why?
<!-- Tell your future self why have you made these changes -->
GitHub limits organizations to a maximum of six pinned repositories. Since we have already reached this limit, we can't pin the new Ruby SDK. At Chad's suggestion, I used [a third-party project](https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#themes) that allows us to include cards in our README that provides a similar look-and-feel to pinned repositories. This PR uses those, adding a new "Pinned" section that includes the existing six pinned repositories plus the Temporal CLI and the Ruby SDK.

**NOTE**: Please allow me to handle the merge, since I will need to coordinate that with unpinning the six repositories that are currently pinned (otherwise they will duplicate what's included here).

## Checklist
<!--- add/delete as needed --->

1. How was this tested:

I tested this in Safari, Firefox, and Google Chrome. In Safari, I alternated between enabling light mode and dark mode my GitHub account preferences. 
