### PR TITLE
Change to "Featured Repositories"

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,11 +24,7 @@ Every message on Twilio, every Coinbase transaction, and every Snap story uses T
 [![Temporal on LinkedIn](https://img.shields.io/badge/Temporal-0A66C2?style=flat&logo=linkedin)](https://www.linkedin.com/company/temporal-technologies/posts/?feedView=all)
 [![@temporalio on X](https://img.shields.io/badge/%40temporalio-black?logo=x)](https://x.com/temporalio)
 
-## Pinned
-[![Temporal Service](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=temporal&show_icons=true&theme=default#gh-light-mode-only)](https://github.com/temporalio/temporal#gh-light-mode-only)
-[![Temporal Service](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=temporal&show_icons=true&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/temporal#gh-dark-mode-only)
-[![Temporal CLI](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=cli&show_icons=true&description_lines_count=1&theme=default#gh-light-mode-only)](https://github.com/temporalio/cli#gh-light-mode-only)
-[![Temporal CLI](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=cli&show_icons=true&description_lines_count=1&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/cli#gh-dark-mode-only)
+## Featured Repositories
 [![Temporal Go SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-go&show_icons=true&theme=default#gh-light-mode-only)](https://github.com/temporalio/sdk-go#gh-light-mode-only)
 [![Temporal Go SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-go&show_icons=true&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/sdk-go#gh-dark-mode-only)
 [![Temporal Java SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-java&show_icons=true&theme=default#gh-light-mode-only)](https://github.com/temporalio/sdk-java#gh-light-mode-only)
@@ -43,8 +39,6 @@ Every message on Twilio, every Coinbase transaction, and every Snap story uses T
 [![Temporal Ruby SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-ruby&show_icons=true&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/sdk-ruby#gh-dark-mode-only)
 [![Temporal PHP SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-php&show_icons=true&theme=default#gh-light-mode-only)](https://github.com/temporalio/sdk-php#gh-light-mode-only)
 [![Temporal PHP SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-php&show_icons=true&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/sdk-php#gh-dark-mode-only)
-[![Temporal Core SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-core&show_icons=true&description_lines_count=1&theme=default#gh-light-mode-only)](https://github.com/temporalio/sdk-core#gh-light-mode-only)
-[![Temporal Core SDK](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=sdk-core&show_icons=true&description_lines_count=1&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/sdk-core#gh-dark-mode-only)
-
-
+[![Temporal CLI](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=cli&show_icons=true&description_lines_count=1&theme=default#gh-light-mode-only)](https://github.com/temporalio/cli#gh-light-mode-only)
+[![Temporal CLI](https://github-readme-stats.vercel.app/api/pin/?username=temporalio&repo=cli&show_icons=true&description_lines_count=1&theme=github_dark#gh-dark-mode-only)](https://github.com/temporalio/cli#gh-dark-mode-only)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I revised the contents of the "Pinned" section and renamed it to "Featured Repositories"

## Why?
<!-- Tell your future self why have you made these changes -->
On Tuesday, we merged [PR #11](https://github.com/temporalio/.github/pull/11), which provided a workaround for the six-item limit that GitHub imposes on the pinned repositories section. Essentially, we created our own "Pinned" section and removed the one provided by GitHub. 

Unfortunately, we discovered that this had the side effect of enabling a "popular repositories" section, which includes an archived repo. GitHub [doesn't allow](https://github.com/orgs/community/discussions/15310) disabling that section—the only remedy is to bring back the "Pinned" section, which I will request separately since it can't be done through a PR. 

This PR retitles the "Pinned" section in the README as "Featured Repositories" to avoid confusion with the soon-to-return "Pinned" section. It also removes two items from the current one: `sdk-core` (since that is generally not intended for application developers) and `temporal` (since that will be in the "Pinned" section). Finally, it moves the `cli` repo to the bottom-right so that it follows the list of SDKs and will be closer to the `temporal` repo once that is re-pinned.



## Checklist
<!--- add/delete as needed --->

How was this tested:
I tested this in Safari, using every one of the themes provided by GitHub (both light and dark mode). I did not test this in other browsers, since this is a change to content, not implementation. It is simply a variation on the previous PR, which I did test in both Chrome and Firefox.
